### PR TITLE
Add workspacefolderbasename support

### DIFF
--- a/src/lint.ts
+++ b/src/lint.ts
@@ -36,7 +36,7 @@ export function analysisResult(diagnosticCollection: vscode.DiagnosticCollection
     diagnosticCollection.clear();
 
     // 1 = path, 2 = line, 3 = severity, 4 = message
-    let regex = /^(.*)\(([0-9]+)\):\s*(\w+):(.*\s+\[.*\])\s+\[([0-9]+)\]/gm;
+    let regex = /^(.*):([0-9]+):\s*(\w+):(.*\s+\[.*\])\s+\[([0-9]+)\]/gm;
     let regexArray: RegExpExecArray;
     let fileData: { [key: string]: RegExpExecArray[] } = {};
     while (regexArray = regex.exec(result)) {
@@ -68,7 +68,7 @@ export function analysisResult(diagnosticCollection: vscode.DiagnosticCollection
 
                 let l = doc.lineAt(line);
                 let r = new vscode.Range(line, 0, line, l.text.length);
-                let d = new vscode.Diagnostic(r, `(${severity}) ${message}`, cpplintSeverityToDiagnosticSeverity(severity));
+                let d = new vscode.Diagnostic(r, `${message}`, cpplintSeverityToDiagnosticSeverity(severity));
                 d.source = 'cpplint';
                 diagnostics.push(d);
             }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -36,7 +36,7 @@ export function runCppLint(filename: string, workspaces: string[], enableworkspa
     let config = ConfigManager.getInstance().getConfig();
     let cpplint = config["cpplintPath"];
     let linelength = "--linelength=" + config['lineLength'];
-    let param: string[] = ['--output=vs7', linelength];
+    let param: string[] = ['--output=eclipse', linelength];
 
     if (config['excludes'].length != 0) {
         config['excludes'].forEach(element => {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "child_process";
 import * as vscode from 'vscode';
 import { ConfigManager } from "./configuration";
+import * as path from 'path';
 
 export function runOnFile() {
     if (vscode.window.activeTextEditor == undefined) {
@@ -69,11 +70,17 @@ export function runCppLint(filename: string, workspaces: string[], enableworkspa
             out.push("Scan workspace: " + workspace);
             let workspaceparam = param;
             if (config['repository'].length != 0) {
-                workspaceparam.push("--repository=" + config["repository"].replace("${workspaceFolder}", workspace));
+                let repo: string = "--repository=" + config["repository"].replace("${workspaceFolder}", workspace);
+                repo = repo.replace("${workspaceFolderBasename}", path.basename(workspace));
+
+                workspaceparam.push(repo);
             }
 
             if (config['root'].length != 0) {
-                workspaceparam.push("--root=" + config["root"].replace("${workspaceFolder}", workspace));
+                let root: string = "--root=" + config["root"].replace("${workspaceFolder}", workspace);
+                root = root.replace("${workspaceFolderBasename}", path.basename(workspace));
+
+                workspaceparam.push(root);
             }
             workspaceparam = workspaceparam.concat(["--recursive", workspace]);
 
@@ -89,11 +96,17 @@ export function runCppLint(filename: string, workspaces: string[], enableworkspa
         }
 
         if (config['repository'].length != 0) {
-            param.push("--repository=" + config["repository"].replace("${workspaceFolder}", workspace));
+            let repo: string = "--repository=" + config["repository"].replace("${workspaceFolder}", workspace);
+            repo = repo.replace("${workspaceFolderBasename}", path.basename(workspace));
+
+            param.push(repo);
         }
 
         if (config['root'].length != 0) {
-            param.push("--root=" + config["root"].replace("${workspaceFolder}", workspace));
+            let root: string = "--root=" + config["root"].replace("${workspaceFolder}", workspace);
+            root = root.replace("${workspaceFolderBasename}", path.basename(workspace));
+
+            param.push(root);
         }
 
         param.push(filename);

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -69,7 +69,7 @@ export function runCppLint(filename: string, workspaces: string[], enableworkspa
             out.push("Scan workspace: " + workspace);
             let workspaceparam = param;
             if (config['repository'].length != 0) {
-                workspaceparam.push("--repository=" + config["repository"].replace("${workspaceFloder}", workspace));
+                workspaceparam.push("--repository=" + config["repository"].replace("${workspaceFolder}", workspace));
             }
 
             if (config['root'].length != 0) {


### PR DESCRIPTION
This adds support for ${workspaceFolderBasename} expansion and changes the output format to 'eclipse' because in earlier versions of cpplint the "severity" is not printed in "vs7" format.

Fixes #21 
