### PR TITLE
Support for custom .py files. Added on-demand mode and clear lints command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ dir c:\ProgramData\Anaconda2\Scripts\cpplint.exe
 
 ## Extension Settings
 
-* `cpplint.cpplintPath`: set cpplint executable path, path on windows should like `c:\\ProgramData\\Anaconda2\\Scripts\\cpplint.exe`
+* `cpplint.cpplintPath`: set cpplint executable path, path on windows should like `c:\\ProgramData\\Anaconda2\\Scripts\\cpplint.exe`. Python files are allowed like `cpplint.py`.
 * `cpplint.lintMode`: set cpplint mode, avialable value are single and workspace
 * `cpplint.lineLength`: set line length strict, default is 80 characters
 * `cpplint.excludes`: set exclude rules, which is related path and shell globbing is preforming, abosluted path is supported right now,

--- a/package.json
+++ b/package.json
@@ -2,12 +2,13 @@
     "name": "cpplint",
     "displayName": "cpplint",
     "description": "code style check tool extension for cpplint",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "publisher": "mine",
     "repository": {
         "type": "Git",
         "url": "https://github.com/secularbird/cpplint-extension"
     },
+    "license": "MIT",
     "engines": {
         "vscode": "^1.21.0"
     },
@@ -21,7 +22,9 @@
         "onLanguage:cpp",
         "onLanguage:c",
         "onCommand:cpplint.runAnalysis",
-        "onCommand:cpplint.runWholeAnalysis"
+        "onCommand:cpplint.runWholeAnalysis",
+        "onCommand:cpplint.lintCurrentFile",
+        "onCommand:cpplint.clearLints"
     ],
     "main": "./out/src/extension",
     "contributes": {
@@ -34,6 +37,16 @@
             {
                 "command": "cpplint.runWholeAnalysis",
                 "title": "Analyze current workspace",
+                "category": "cpplinter"
+            },
+            {
+                "command": "cpplint.lintCurrentFile",
+                "title": "Lint current file",
+                "category": "cpplinter"
+            },
+            {
+                "command": "cpplint.clearLints",
+                "title": "Clear cpplint problems and squiggles",
                 "category": "cpplinter"
             }
         ],
@@ -51,9 +64,10 @@
                     "default": "single",
                     "enum": [
                         "single",
-                        "workspace"
+                        "workspace",
+                        "single-demand"
                     ],
-                    "description": "single is fast, only provides information of current active file, workspace is slow, provides informations of the whole workspace"
+                    "description": "single is fast, only provides information of current active file, workspace is slow, provides informations of the whole workspace, single-demand works only when manually invoking the command for a single file."
                 },
                 "cpplint.lineLength": {
                     "type": "number",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -57,6 +57,14 @@ export class ConfigManager {
         }
     }
 
+    public isWorkspaceMode(): boolean {
+        if (this.config['lintMode'] == 'workspace') {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     public isSupportLanguage(language: string): boolean {
         if (this.config["languages"].indexOf(language) >= 0) {
             return true;
@@ -72,8 +80,15 @@ export class ConfigManager {
         if (settings) {
             var cpplintPath = this.findCpplintPath(settings);
 
+            let threeLastChars = cpplintPath.substring(cpplintPath.length - 3);
+            if (threeLastChars === ".py"){
+                this.config['usePyFile'] = true;
+            } else {
+                this.config['usePyFile'] = false;
+            }
+
             if (!existsSync(cpplintPath)) {
-                vscode.window.showErrorMessage('Cpplint: Could not find cpplint executable');
+                vscode.window.showErrorMessage('Cpplint: Could not find cpplint executable.');
             }
 
             this.config['cpplintPath'] = cpplintPath;

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -36,7 +36,17 @@ export function runCppLint(filename: string, workspaces: string[], enableworkspa
     let config = ConfigManager.getInstance().getConfig();
     let cpplint = config["cpplintPath"];
     let linelength = "--linelength=" + config['lineLength'];
-    let param: string[] = ['--output=eclipse', linelength];
+    let param: string[] = [];
+    let exec: string;
+    // If using a custom python script modify the args and exec to call spawn.
+    if (config['usePyFile'] == true ){
+        exec = "python";
+        param = [cpplint, '--output=eclipse', linelength];
+    }
+    else{
+        exec = cpplint;
+        param = ['--output=eclipse', linelength];
+    }
 
     if (config['excludes'].length != 0) {
         config['excludes'].forEach(element => {
@@ -84,7 +94,7 @@ export function runCppLint(filename: string, workspaces: string[], enableworkspa
             }
             workspaceparam = workspaceparam.concat(["--recursive", workspace]);
 
-            let output = lint(cpplint, workspaceparam);
+            let output = lint(exec, workspaceparam);
             out = output;
         }
         return out.join('\n');
@@ -110,7 +120,7 @@ export function runCppLint(filename: string, workspaces: string[], enableworkspa
         }
 
         param.push(filename);
-        let output = lint(cpplint, param);
+        let output = lint(exec, param);
         let end = 'CppLint ended: ' + new Date().toString();
         let out = output;
         return out.join('\n');


### PR DESCRIPTION
Added on-demand command for users that doesn't want that linter is automatically executed when opening or saving files.
Added clear lints command for clearing the file squiggles and problems.

Rationale: when working in a project not following the standards, or a project with big files, I had to disable the extension even though I wanted to use it later. With this mode, the user controls when the linter is being executed. Also, allows the user to clear squiggles on demand if needed as it can be a hassle sometimes.

Added support for custom .py files by checking cpplintPath for ends in ".py". This is useful for users that have custom versions of cpplint, even though 100% compatibility with other versions is not guaranteed. Fixes #31.

Fixed missing license warning in package.json.